### PR TITLE
fix: 升级 algo 包版本以消除其在 Typst 0.13 下的警告

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ typst watch ./templates/<template-name>.typ --root ./
 若要书写和引用伪代码，您可以使用 `algorithm-figure`，为此，您需要导入 `algo` 或 `lovelace` 包。
 
 ```typ
-#import "@preview/algo:0.3.4": algo, i, d, comment, code
+#import "@preview/algo:0.3.6": algo, i, d, comment, code
 
 #import "@preview/lovelace:0.2.0": *
 ```

--- a/templates/shenzhen-master.typ
+++ b/templates/shenzhen-master.typ
@@ -460,7 +460,7 @@ $ C_2 = 3.5 / D_p ((1 - psi)) / psi^3 $ <formula-2>
 == 伪代码
 
 #[
-  #import "@preview/algo:0.3.4": algo, i, d, comment, code
+  #import "@preview/algo:0.3.6": algo, i, d, comment, code
 
   使用`@algo:`来引用伪代码， 支持`algo`和`lovelace`包，如#[@algo:XXX算法]、#[@algo:XXXX算法]和#[@algo:lovelace-algo]所示
 

--- a/templates/universal-bachelor.typ
+++ b/templates/universal-bachelor.typ
@@ -431,7 +431,7 @@ $ C_2 = 3.5 / D_p ((1 - psi)) / psi^3 $ <formula-2>
 == 伪代码
 
 #[
-  #import "@preview/algo:0.3.4": algo, i, d, comment, code
+  #import "@preview/algo:0.3.6": algo, i, d, comment, code
 
   使用`@algo:`来引用伪代码， 支持`algo`和`lovelace`包，如#[@algo:XXX算法]、#[@algo:XXXX算法]和#[@algo:lovelace-algo]所示
 

--- a/templates/universal-doctor.typ
+++ b/templates/universal-doctor.typ
@@ -508,7 +508,7 @@ $ C_2 = 3.5 / D_p ((1 - psi)) / psi^3 $ <formula-2>
 #enheading()[Pseudocode]
 
 #[
-  #import "@preview/algo:0.3.4": algo, i, d, comment, code
+  #import "@preview/algo:0.3.6": algo, i, d, comment, code
 
   使用`@algo:`来引用伪代码， 支持`algo`和`lovelace`包，如#[@algo:XXX算法]、#[@algo:XXXX算法]和#[@algo:lovelace-algo]所示
 


### PR DESCRIPTION
消除在 Typst 0.13 版本下编译时造成的如下警告:

```
warning: comparing strings with types is deprecated
    ┌─ @preview/algo:0.3.4/algo.typ:187:11
    │
187 │         if type(param) == "string" {
    │            ^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: compare with the literal type instead
    = hint: this comparison will always return `false` in future Typst releases
```
